### PR TITLE
TA-2651 set up events backend feature flag

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,6 @@ module.exports = {
     countEndpoint: process.env.EVENTS_API_COUNT_ENDPOINT,
 
     // TODO: remove this feature flag function when new events backend is ready to be enabled
-    getBackendSourceToggle: () => true // process.env.EVENTS_BACKEND_SOURCE_TOGGLE
+    getBackendSourceToggle: () => process.env.EVENTS_BACKEND_SOURCE_TOGGLE
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,6 @@ module.exports = {
     countEndpoint: process.env.EVENTS_API_COUNT_ENDPOINT,
 
     // TODO: remove this feature flag function when new events backend is ready to be enabled
-    getBackendSourceToggle: () => process.env.EVENTS_BACKEND_SOURCE_TOGGLE
+    getBackendSourceToggle: () => process.env.EVENTS_BACKEND_SOURCE_DRUPAL_8_TOGGLE
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,9 @@ module.exports = {
   eventsApi: {
     hostname: process.env.EVENTS_HOSTNAME,
     endpoint: process.env.EVENTS_API_ENDPOINT,
-    countEndpoint: process.env.EVENTS_API_COUNT_ENDPOINT
+    countEndpoint: process.env.EVENTS_API_COUNT_ENDPOINT,
+
+    // TODO: remove this feature flag function when new events backend is ready to be enabled
+    backendSourceToggle: true // process.env.EVENTS_BACKEND_SOURCE_TOGGLE
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,6 @@ module.exports = {
     countEndpoint: process.env.EVENTS_API_COUNT_ENDPOINT,
 
     // TODO: remove this feature flag function when new events backend is ready to be enabled
-    backendSourceToggle: true // process.env.EVENTS_BACKEND_SOURCE_TOGGLE
+    getBackendSourceToggle: () => true // process.env.EVENTS_BACKEND_SOURCE_TOGGLE
   }
 }

--- a/src/content.js
+++ b/src/content.js
@@ -76,7 +76,7 @@ async function fetchContentById (params, headers) {
         console.error('Error fetching data: ', e)
         return {
           statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-          body: `Server Error, ${e}`
+          body: `B---- Server Error, ${e}`
         }
       }
     } else {
@@ -108,7 +108,7 @@ async function fetchContentByType (pathParams, queryStringParameters) {
         console.error('Error fetching data: ', e)
         return {
           statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-          body: `Server Error, ${e}`
+          body: `A---- Server Error, ${e}`
         }
       }
     } else {

--- a/src/content.js
+++ b/src/content.js
@@ -1,4 +1,5 @@
 const HttpStatus = require('http-status-codes')
+const config = require('./config.js')
 const {
   fetchAnnouncements,
   fetchContacts,
@@ -23,8 +24,11 @@ const { runSearch } = require('./service/search.js')
 const { getSuggestedRoutes } = require('./service/suggested-routes.js')
 
 const fetchFunctions = {
-  node: fetchFormattedNode,
-  event: fetchEventById
+  node: fetchFormattedNode
+}
+
+if (!config.eventsApi.getBackendSourceToggle()) {
+  fetchFunctions.event = fetchEventById
 }
 
 const fetchContentTypeFunctions = {

--- a/src/content.js
+++ b/src/content.js
@@ -76,7 +76,7 @@ async function fetchContentById (params, headers) {
         console.error('Error fetching data: ', e)
         return {
           statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-          body: `B---- Server Error, ${e}`
+          body: `Server Error, ${e}`
         }
       }
     } else {
@@ -108,7 +108,7 @@ async function fetchContentByType (pathParams, queryStringParameters) {
         console.error('Error fetching data: ', e)
         return {
           statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-          body: `A---- Server Error, ${e}`
+          body: `Server Error, ${e}`
         }
       }
     } else {

--- a/src/content.js
+++ b/src/content.js
@@ -23,43 +23,20 @@ const { fetchOffices } = require('./service/office-search.js')
 const { runSearch } = require('./service/search.js')
 const { getSuggestedRoutes } = require('./service/suggested-routes.js')
 
-const fetchFunctions = {
-  node: fetchFormattedNode
-}
-
-if (!config.eventsApi.getBackendSourceToggle()) {
-  fetchFunctions.event = fetchEventById
-}
-
-const fetchContentTypeFunctions = {
-  announcements: fetchAnnouncements,
-  articles: fetchArticles,
-  blog: fetchBlog,
-  blogs: fetchBlogs,
-  contacts: fetchContacts,
-  counsellorCta: fetchCounsellorCta,
-  course: fetchCourse,
-  courses: fetchCourses,
-  disaster: fetchDisaster,
-  documents: fetchDocuments,
-  events: fetchEvents,
-  mainMenu: fetchMainMenu,
-  nodes: fetchNodes,
-  offices: fetchOffices,
-  officesRaw: fetchOfficesRaw,
-  persons: fetchPersons,
-  search: runSearch,
-  siteMap: fetchFormattedMenu,
-  suggestedRoutes: getSuggestedRoutes,
-  taxonomys: fetchTaxonomys,
-  authors: getAuthors
-}
-
 async function fetchContentById (params, headers) {
+  const fetchFunctionsMap = {
+    node: fetchFormattedNode
+  }
+
+  if (!config.eventsApi.getBackendSourceToggle()) {
+    fetchFunctionsMap.event = fetchEventById
+  }
+
   if (params && params.type && params.id) {
     const type = params.type
     const id = params.id
-    const fetchFunction = fetchFunctions[type]
+    const fetchFunction = fetchFunctionsMap[type]
+
     if (fetchFunction) {
       try {
         let result = await fetchFunction(id, {
@@ -98,9 +75,34 @@ async function fetchContentById (params, headers) {
 }
 
 async function fetchContentByType (pathParams, queryStringParameters) {
+  const typeFunctionsMap = {
+    announcements: fetchAnnouncements,
+    articles: fetchArticles,
+    blog: fetchBlog,
+    blogs: fetchBlogs,
+    contacts: fetchContacts,
+    counsellorCta: fetchCounsellorCta,
+    course: fetchCourse,
+    courses: fetchCourses,
+    disaster: fetchDisaster,
+    documents: fetchDocuments,
+    events: fetchEvents,
+    mainMenu: fetchMainMenu,
+    nodes: fetchNodes,
+    offices: fetchOffices,
+    officesRaw: fetchOfficesRaw,
+    persons: fetchPersons,
+    search: runSearch,
+    siteMap: fetchFormattedMenu,
+    suggestedRoutes: getSuggestedRoutes,
+    taxonomys: fetchTaxonomys,
+    authors: getAuthors
+  }
+
   if (pathParams && pathParams.type) {
     const type = pathParams.type
-    const fetchFunction = fetchContentTypeFunctions[type]
+    const fetchFunction = typeFunctionsMap[type]
+
     if (fetchFunction) {
       try {
         let result = await fetchFunction(queryStringParameters)

--- a/src/content.test.js
+++ b/src/content.test.js
@@ -55,10 +55,11 @@ describe('# Content Handler', () => {
     })
 
     it('should display invalid endpoint message for event data with getBackendSourceToggle set to true', async () => {
+      const id = 1
       getBackendSourceToggleStub.returns(true)
 
       let expected = { statusCode: HttpStatus.NOT_FOUND, body: 'Unknown type event' }
-      let result = await contentHandler.fetchContentById({ type: 'event', id: 1 })
+      let result = await contentHandler.fetchContentById({ type: 'event', id })
 
       expect(result).to.deep.equal(expected)
     })
@@ -70,10 +71,11 @@ describe('# Content Handler', () => {
     })
 
     it('should display invalid endpoint message for unknown data type', async () => {
-      const dataType = 'fake data type'
+      const invalidType = 'fake data type'
+      const id = 1
 
-      let expected = { statusCode: HttpStatus.NOT_FOUND, body: `Unknown type ${dataType}` }
-      let result = await contentHandler.fetchContentById({ type: dataType, id: 1 })
+      let expected = { statusCode: HttpStatus.NOT_FOUND, body: `Unknown type ${invalidType}` }
+      let result = await contentHandler.fetchContentById({ type: invalidType, id })
 
       expect(result).to.deep.equal(expected)
     })
@@ -89,13 +91,6 @@ describe('# Content Handler', () => {
   describe('fetchContentByType', () => {
     beforeEach(() => {
       getBackendSourceToggleStub.returns(true)
-    })
-
-    it('should respond with status code OK when valid data type is given in the path', async () => {
-      let expected = { statusCode: HttpStatus.OK }
-      let result = await contentHandler.fetchContentByType({ type: 'nodes' })
-
-      expect(result.statusCode).to.deep.equal(expected.statusCode)
     })
 
     it('should display invalid endpoint message for unknown data type', async () => {

--- a/src/content.test.js
+++ b/src/content.test.js
@@ -8,36 +8,109 @@ let expect = chai.expect
 let contentHandler
 let events = require('./service/events.js')
 const HttpStatus = require('http-status-codes')
+const config = require('./config.js')
 
 describe('# Content Handler', () => {
-  let eventStub
+  let eventStub, getBackendSourceToggleStub
 
   before(() => {
     eventStub = sinon.stub(events, 'fetchEventById')
+    getBackendSourceToggleStub = sinon.stub(config.eventsApi, 'getBackendSourceToggle')
     contentHandler = require('./content.js') // this is a small workaround for the way the content handler imports service modules
   })
 
   afterEach(() => {
     eventStub.reset()
+    getBackendSourceToggleStub.reset()
   })
 
   after(() => {
     eventStub.restore()
+    getBackendSourceToggleStub.restore()
   })
 
-  describe('fetchContentById', () => {
+  // TODO: remove this describe block when feature flag, getBackendSourceToggle, for events backend is removed
+  // fetchEventById will no longer be a function
+  describe('fetchContentById for event id mapping', () => {
     it('should respond with event data when a valid id is given in the path', async () => {
       let data = { title: 'thisisatitle' }
+
+      getBackendSourceToggleStub.returns(false)
       eventStub.withArgs(1).returns(data)
+
+      let expected = { statusCode: HttpStatus.OK, body: data }
       let result = await contentHandler.fetchContentById({ type: 'event', id: 1 })
-      let expected = {statusCode: HttpStatus.OK, body: data}
+
       expect(result).to.deep.equal(expected)
     })
 
     it('should respond with a 404 when an invalid id is given in the path', async () => {
+      getBackendSourceToggleStub.returns(false)
       eventStub.returns(null)
+
+      let expected = { statusCode: HttpStatus.NOT_FOUND, body: 'Unable to find event with id 1' }
       let result = await contentHandler.fetchContentById({ type: 'event', id: 1 })
-      let expected = {statusCode: HttpStatus.NOT_FOUND, body: 'Unable to find event with id 1'}
+
+      expect(result).to.deep.equal(expected)
+    })
+
+    it('should display invalid endpoint message for event data with getBackendSourceToggle set to true', async () => {
+      getBackendSourceToggleStub.returns(true)
+
+      let expected = { statusCode: HttpStatus.NOT_FOUND, body: 'Unknown type event' }
+      let result = await contentHandler.fetchContentById({ type: 'event', id: 1 })
+
+      expect(result).to.deep.equal(expected)
+    })
+  })
+
+  describe('fetchContentById', () => {
+    beforeEach(() => {
+      getBackendSourceToggleStub.returns(true)
+    })
+
+    it('should display invalid endpoint message for unknown data type', async () => {
+      const dataType = 'fake data type'
+
+      let expected = { statusCode: HttpStatus.NOT_FOUND, body: `Unknown type ${dataType}` }
+      let result = await contentHandler.fetchContentById({ type: dataType, id: 1 })
+
+      expect(result).to.deep.equal(expected)
+    })
+
+    it('should display invalid endpoint message when no type and/or id is declared', async () => {
+      let expected = { statusCode: HttpStatus.BAD_REQUEST, body: `Incorrect request format: missing type or id` }
+      let result = await contentHandler.fetchContentById()
+
+      expect(result).to.deep.equal(expected)
+    })
+  })
+
+  describe('fetchContentByType', () => {
+    beforeEach(() => {
+      getBackendSourceToggleStub.returns(true)
+    })
+
+    it('should respond with status code OK when valid data type is given in the path', async () => {
+      let expected = { statusCode: HttpStatus.OK }
+      let result = await contentHandler.fetchContentByType({ type: 'nodes' })
+
+      expect(result.statusCode).to.deep.equal(expected.statusCode)
+    })
+
+    it('should display invalid endpoint message for unknown data type', async () => {
+      const dataType = 'fake data type'
+
+      let expected = { statusCode: HttpStatus.NOT_FOUND, body: `Unknown type ${dataType}` }
+      let result = await contentHandler.fetchContentByType({ type: dataType })
+
+      expect(result).to.deep.equal(expected)
+    })
+
+    it('should display invalid endpoint message when no type is declared', async () => {
+      let expected = { statusCode: HttpStatus.BAD_REQUEST, body: `Incorrect request format: missing type` }
+      let result = await contentHandler.fetchContentByType()
+
       expect(result).to.deep.equal(expected)
     })
   })

--- a/src/service/events.js
+++ b/src/service/events.js
@@ -159,7 +159,7 @@ async function fetchTotalLength (params) {
 async function fetchEvents (query) {
   let result
   if (config.eventsApi.getBackendSourceToggle()) {
-    let results = [{ id: 1234, name: 'Mock Event found by fetchEvents function' }]
+    let results = [{ id: 1234, title: 'Mock Event found by fetchEvents function' }]
     results = results.filter(item => item)
 
     const totalCount = results.length

--- a/src/service/events.js
+++ b/src/service/events.js
@@ -136,9 +136,9 @@ function mapD7EventDataToBetterSchema (item) {
 
 async function fetchEventById (id) {
   let result = {}
-  if (config.eventsApi.getBackendSourceToggle()){
+  if (config.eventsApi.getBackendSourceToggle()) {
     // let result = await eventClient.getEvents({ nid: id })
-    const results = [{ id: 0000, name: 'Mock Event found by fetchEventById function' }]
+    const results = [{ id: 1234, name: 'Mock Event found by fetchEventById function' }]
     if (Array.isArray(results) && results.length !== 0) {
       result = results[0]
     }
@@ -171,9 +171,9 @@ async function fetchTotalLength (params) {
 
 async function fetchEvents (query) {
   let result
-  if (config.eventsApi.getBackendSourceToggle()){
+  if (config.eventsApi.getBackendSourceToggle()) {
     // let results = await eventClient.getEvents(query)
-    let results = [{ id: 0000, name: 'Mock Event found by fetchEvents function' }]
+    let results = [{ id: 1234, name: 'Mock Event found by fetchEvents function' }]
     results = results.filter(item => item)
 
     const totalCount = await fetchTotalLength(query)

--- a/src/service/events.js
+++ b/src/service/events.js
@@ -136,7 +136,7 @@ function mapD7EventDataToBetterSchema (item) {
 
 async function fetchEventById (id) {
   let result = {}
-  if (config.eventsApi.backendSourceToggle){
+  if (config.eventsApi.getBackendSourceToggle()){
     // let result = await eventClient.getEvents({ nid: id })
     const results = [{ id: 0000, name: 'Mock Event found by fetchEventById function' }]
     if (Array.isArray(results) && results.length !== 0) {
@@ -171,7 +171,7 @@ async function fetchTotalLength (params) {
 
 async function fetchEvents (query) {
   let result
-  if (config.eventsApi.backendSourceToggle){
+  if (config.eventsApi.getBackendSourceToggle()){
     // let results = await eventClient.getEvents(query)
     let results = [{ id: 0000, name: 'Mock Event found by fetchEvents function' }]
     results = results.filter(item => item)

--- a/src/service/events.js
+++ b/src/service/events.js
@@ -128,20 +128,12 @@ function mapD7EventDataToBetterSchema (item) {
 }
 
 async function fetchEventById (id) {
-  let result = {}
-  if (config.eventsApi.getBackendSourceToggle()) {
-    // let result = await eventClient.getEvents({ nid: id })
-    const results = [{ id: 1234, name: 'Mock Event found by fetchEventById function' }]
-    if (Array.isArray(results) && results.length !== 0) {
-      result = results[0]
-    }
+  let result = await eventClient.getEvents({ nid: id })
+  if (Array.isArray(result) && result.length !== 0) {
+    return mapD7EventDataToBetterSchema(result[0])
   } else {
-    const results = await eventClient.getEvents({ nid: id })
-    if (Array.isArray(results) && results.length !== 0) {
-      result = mapD7EventDataToBetterSchema(results[0])
-    }
+    return {}
   }
-  return result
 }
 
 async function fetchTotalLength (params) {
@@ -162,14 +154,15 @@ async function fetchTotalLength (params) {
   return totalCount
 }
 
+// TODO: feature flag used here for events via getBackendSourceToggle
+// all other functions in this file can also be removed when feature flag is removed
 async function fetchEvents (query) {
   let result
   if (config.eventsApi.getBackendSourceToggle()) {
-    // let results = await eventClient.getEvents(query)
     let results = [{ id: 1234, name: 'Mock Event found by fetchEvents function' }]
     results = results.filter(item => item)
 
-    const totalCount = await fetchTotalLength(query)
+    const totalCount = results.length
 
     result = { count: totalCount, items: results }
   } else {

--- a/src/service/events.js
+++ b/src/service/events.js
@@ -3,10 +3,6 @@ const moment = require('moment-timezone')
 const he = require('he')
 const config = require('../config')
 
-// TODO: remove code tagged with #featureflag when new events backend is ready to be enabled
-// will also need to remove functions related to obtaining events from D7
-
-// #featureFlag: this function should be removed
 function translateQueryParamsForD7 (query) {
   const queryObj = query || {}
   const { q, address, dateRange, distance, start } = queryObj
@@ -59,7 +55,6 @@ function translateQueryParamsForD7 (query) {
   return params
 }
 
-// #featureFlag: this function should be removed
 function clean (value) {
   if (Array.isArray(value) && value.length === 0) {
     return null
@@ -68,7 +63,6 @@ function clean (value) {
   }
 }
 
-// #featureFlag: this function should be removed
 function formatDate (dateString, timezone) {
   if (dateString) {
     return moment.utc(dateString).format()
@@ -77,7 +71,6 @@ function formatDate (dateString, timezone) {
   }
 }
 
-// #featureFlag: this function should be removed
 function mapD7EventDataToBetterSchema (item) {
   try {
     if (!item) {

--- a/src/service/events.test.js
+++ b/src/service/events.test.js
@@ -10,13 +10,14 @@ chai.should()
 const events = require('./events')
 const mockD7Response1 = require('./events.test.json')
 const expectedEventsData1 = require('./events.output.test.json')
+const config = require('../config.js')
 
 function makeArray (n) {
   return new Array(n).fill(0)
 }
 
 describe('Event Service', () => {
-  let eventClientStub, eventClientCountStub, clock, todayDateString, tomorrowDateString, sevenDaysFromNowDateString, thirtyDaysFromNowDateString
+  let eventClientStub, eventClientCountStub, getBackendSourceToggleStub, clock, todayDateString, tomorrowDateString, sevenDaysFromNowDateString, thirtyDaysFromNowDateString
 
   before(() => {
     clock = sinon.useFakeTimers(new Date(2016, 2, 15).getTime())
@@ -26,21 +27,25 @@ describe('Event Service', () => {
     thirtyDaysFromNowDateString = '2016-04-14'
     eventClientStub = sinon.stub(eventClient, 'getEvents')
     eventClientCountStub = sinon.stub(eventClient, 'getEventCount')
+    getBackendSourceToggleStub = sinon.stub(config.eventsApi, 'getBackendSourceToggle')
   })
 
   beforeEach(() => {
     eventClientCountStub.returns([1, 2, 3])
+    getBackendSourceToggleStub.returns(false)
   })
 
   afterEach(() => {
     eventClientCountStub.reset()
     eventClientStub.reset()
+    getBackendSourceToggleStub.reset()
   })
 
   after(() => {
     clock.restore()
     eventClientStub.restore()
     eventClientCountStub.restore()
+    getBackendSourceToggleStub.restore()
   })
 
   describe('fetchEventById', () => {

--- a/src/service/events.test.js
+++ b/src/service/events.test.js
@@ -15,7 +15,8 @@ function makeArray (n) {
   return new Array(n).fill(0)
 }
 
-describe('Event Service', () => {
+// TODO: remove this describe block when feature flag, getBackendSourceToggle, for events backend is removed
+describe('Event Service for D7', () => {
   let eventClientStub, eventClientCountStub, getBackendSourceToggleStub, clock, todayDateString, tomorrowDateString, sevenDaysFromNowDateString, thirtyDaysFromNowDateString
 
   before(() => {
@@ -157,4 +158,19 @@ describe('Event Service', () => {
     })
   })
 })
+
+describe('Event Service', () => {
+  describe('fetchEvents', () => {
+    it('should return response in the desired format', async() => {
+      const getBackendSourceToggleStub = sinon.stub(config.eventsApi, 'getBackendSourceToggle')
+      getBackendSourceToggleStub.returns(true)
+
+      const results = await events.fetchEvents()
+      results.should.be.an('object')
+      results.should.have.property('count').be.a('number')
+      results.should.have.property('items').be.an('array')
+    })
+  })
+})
+
 /* eslint-enable no-unused-expressions */

--- a/src/service/events.test.js
+++ b/src/service/events.test.js
@@ -6,7 +6,6 @@ let sinon = require('sinon')
 let chai = require('chai')
 chai.should()
 
-// const { fn as momentPrototype } = require("moment")
 const events = require('./events')
 const mockD7Response1 = require('./events.test.json')
 const expectedEventsData1 = require('./events.output.test.json')


### PR DESCRIPTION
- [x] content api contains a feature flag (controlled by environment variable set in infrastructure repo), which when enabled will allow the new implementation of consuming events indirectly via D8 instead of D7
- [x] set up for the content api to return temporary mock events.json data when `/api/content/search/events.json` is accessed if feature flag was enabled
- [x] disable `/api/content/search/event/#.json` endpoint in the content api when feature flag is enabled

Feature flag is currently enabled in amy.ussba.io