### PR TITLE
TA-2593 added office param to document search

### DIFF
--- a/src/service/documents.js
+++ b/src/service/documents.js
@@ -27,7 +27,7 @@ function filterDocuments (params, docs) {
       (!isEmpty(doc.programs) && doc.programs.includes(params.program))
     const matchesType = !params.type || params.type === 'all' || doc.documentIdType === params.type
     const matchesDocumentType = !params.documentType || params.documentType === 'all' || doc.documentIdType === params.documentType
-    const matchesOffice = !params.office || params.office === 'all' || doc.office === params.office
+    const matchesOffice = !params.office || params.office === 'all' || doc.office === Number(params.office)
     return (
       matchesType &&
       matchesDocumentType &&

--- a/src/service/documents.js
+++ b/src/service/documents.js
@@ -27,12 +27,14 @@ function filterDocuments (params, docs) {
       (!isEmpty(doc.programs) && doc.programs.includes(params.program))
     const matchesType = !params.type || params.type === 'all' || doc.documentIdType === params.type
     const matchesDocumentType = !params.documentType || params.documentType === 'all' || doc.documentIdType === params.documentType
+    const matchesOffice = !params.office || params.office === 'all' || doc.office === params.office
     return (
       matchesType &&
       matchesDocumentType &&
       matchesProgram &&
       matchesActivitys &&
       matchesActivity &&
+      matchesOffice &&
       matchesUrl &&
       (!params.searchTerm ||
         params.searchTerm === 'all' ||

--- a/src/service/documents.test.js
+++ b/src/service/documents.test.js
@@ -87,16 +87,30 @@ describe('Searching for documents', () => {
   })
   it("should return only the matching documents when provided with a 'documentActivity' parameter", async () => {
     getKeyStub.withArgs('documents').returns(Promise.resolve(documents))
-
+    
     const activity = 'contracting stuff'
     const results = await fetchDocuments({ documentActivity: activity })
     const resultsTotal = results['count']
     const resultsDocuments = results['items']
-
+    
     expect(resultsTotal).to.equal(2)
     expect(resultsDocuments).to.have.lengthOf(resultsTotal)
     resultsDocuments.forEach(function (document) {
       expect(document.activitys).to.include(activity)
+    })
+  })
+  it("should return only the matching documents when provided with a 'office' parameter", async () => {
+    getKeyStub.withArgs('documents').returns(Promise.resolve(documents))
+
+    const documentOffice = 12345
+    const results = await fetchDocuments({ office: documentOffice })
+    const resultsTotal = results['count']
+    const resultsDocuments = results['items']
+
+    expect(resultsTotal).to.equal(3)
+    expect(resultsDocuments).to.have.lengthOf(resultsTotal)
+    resultsDocuments.forEach(function (document) {
+      expect(document.office).to.equal(documentOffice)
     })
   })
   it('should return only the matching documents when provided with multiple valid parameters', async () => {
@@ -193,16 +207,19 @@ describe('Searching for documents', () => {
     const documentType = 'full type'
     const activity = 'paging activity'
     const program = 'paging program'
+    const office = 12345
     const control = await fetchDocuments({ searchTerm: keyword,
       documentActivity: activity,
       documentType: documentType,
-      program: program })
+      program: program,
+      office: office })
     const controlTotal = control['count']
     const controlDocuments = control['items']
     const results = await fetchDocuments({ searchTerm: keyword,
       documentActivity: activity,
       documentType: documentType,
       program: program,
+      office: office,
       start: 1,
       end: 3 })
     const resultsTotal = results['count']
@@ -217,6 +234,7 @@ describe('Searching for documents', () => {
       expect(document.documentIdType).to.equal(documentType)
       expect(document.activitys).to.include(activity)
       expect(document.programs).to.include(program)
+      expect(document.office).to.equal(office)
     })
   })
 })

--- a/src/service/documents.test.js
+++ b/src/service/documents.test.js
@@ -87,12 +87,12 @@ describe('Searching for documents', () => {
   })
   it("should return only the matching documents when provided with a 'documentActivity' parameter", async () => {
     getKeyStub.withArgs('documents').returns(Promise.resolve(documents))
-    
+
     const activity = 'contracting stuff'
     const results = await fetchDocuments({ documentActivity: activity })
     const resultsTotal = results['count']
     const resultsDocuments = results['items']
-    
+
     expect(resultsTotal).to.equal(2)
     expect(resultsDocuments).to.have.lengthOf(resultsTotal)
     resultsDocuments.forEach(function (document) {

--- a/src/test-data/documents.js
+++ b/src/test-data/documents.js
@@ -200,6 +200,7 @@ const documents = [
     'type': 'document',
     'title': 'Some SBA Document',
     'id': 1113,
+    'office': 54321,
     'updated': 1512075693,
     'created': 1504815259,
     'langCode': 'en',
@@ -332,6 +333,7 @@ const documents = [
     'type': 'document',
     'title': 'Page of a Document',
     'id': 1117,
+    'office': 12345,
     'updated': 1512075693,
     'created': 1504815259,
     'langCode': 'en',
@@ -365,6 +367,41 @@ const documents = [
     'type': 'document',
     'title': 'Page of a Document',
     'id': 1118,
+    'office': 12345,
+    'updated': 1512075693,
+    'created': 1504815259,
+    'langCode': 'en',
+    'url': '/document/some-doc'
+  },
+  {
+    'activitys': [
+      'paging activity'
+    ],
+    'documentIdNumber': '5000-4021',
+    'documentIdType': 'full type',
+    'files': [
+      {
+        'id': 1118,
+        'type': 'docFile',
+        'effectiveDate': '2017-08-28',
+        'expirationDate': null,
+        'fileUrl': '/sites/default/files/2017-09/5000-4021.pdf',
+        'version': '1'
+      }
+    ],
+    'officeLink': {
+      'url': '/offices/headquarters/oca',
+      'title': 'Office of Capital Access'
+    },
+    'ombNumber': {},
+    'programs': [
+      'paging program'
+    ],
+    'summary': 'A summary',
+    'type': 'document',
+    'title': 'Page of a Document',
+    'id': 1119,
+    'office': 12345,
     'updated': 1512075693,
     'created': 1504815259,
     'langCode': 'en',


### PR DESCRIPTION
Deployed to ryan's environment 
[https://ryan.ussba.io/api/content/search/documents.json](https://ryan.ussba.io/api/content/search/documents.json)
there is a document in the environment associated with office `15850`