### PR TITLE
TA-3441 updated to transform cloudsearch formatting to be like daisho

### DIFF
--- a/src/service/article-search.js
+++ b/src/service/article-search.js
@@ -26,16 +26,16 @@ function ArticleSearch () {
     let categoryFilterString = ''
 
     if (params.relatedOffice && !isNaN(Number(params.relatedOffice))) {
-      officeFilters.push(`(or related_offices: '${params.relatedOffice}')`)
+      officeFilters.push(`related_offices: '${params.relatedOffice}'`)
     }
     if (params.office && !isNaN(Number(params.office))) {
-      officeFilters.push(`(or office: '${params.office}')`)
+      officeFilters.push(`office: '${params.office}'`)
     }
     if (params.region) {
-      officeFilters.push(`(or region: '${cloudsearch.formatString(params.region)}')`)
+      officeFilters.push(`region: '${cloudsearch.formatString(params.region)}'`)
     }
     if (params.national && params.national === 'true') {
-      officeFilters.push(`(or region: 'National')`)
+      officeFilters.push(`region: 'National'`)
     }
 
     if (officeFilters.length === 1) {
@@ -54,8 +54,12 @@ function ArticleSearch () {
 
     programFilterString.length > 0 && filters.push(programFilterString)
     categoryFilterString.length > 0 && filters.push(categoryFilterString)
-    if (officeFilterString.length > 0 || filters.length > 0) {
-      filterString += `(and ${officeFilterString} ${filters.join(' ')})`
+    if (officeFilterString.length > 0 && filters.length === 0) {
+      filterString += `(or ${officeFilterString})`
+    } else if (officeFilterString.length === 0 && filters.length > 0) {
+      filterString += `(and ${filters.join(' ')})`
+    } else if (officeFilterString.length > 0 && filters.length > 0) {
+      filterString += `(and (or ${officeFilterString}) ${filters.join(' ')})`
     }
 
     return filterString

--- a/src/service/article-search.js
+++ b/src/service/article-search.js
@@ -82,6 +82,30 @@ function ArticleSearch () {
     return result
   }
 
+  this.transformToDaishoArticleObjectFormat = function (articles) {
+    const remappedArticles = []
+    for (let i = 0; i < articles.length; i++) {
+      const { fields } = articles[i]
+      const remappedArticle = {
+        id: Number(articles[i].id),
+        category: fields.article_category ? fields.article_category : [],
+        office: fields.office ? Number(fields.office[0]) : {},
+        programs: fields.article_programs ? fields.article_programs : [],
+        region: fields.region ? fields.region : [],
+        relatedOffices: fields.related_offices ? fields.related_offices.map(office => Number(office)) : [],
+        summary: fields.summary ? fields.summary[0] : '',
+        type: 'article',
+        title: fields.title ? fields.title[0] : '',
+        created: fields.created ? Number(fields.created[0]) : {},
+        updated: fields.updated ? Number(fields.updated[0]) : {},
+        url: fields.url ? fields.url[0] : ''
+      }
+
+      remappedArticles.push(remappedArticle)
+    }
+    return remappedArticles
+  }
+
   this.fetchArticles = async function (queryParams) {
     const query = queryParams.searchTerm ? this.buildQuery(queryParams.searchTerm) : 'matchall'
     let cloudParams = {
@@ -104,7 +128,7 @@ function ArticleSearch () {
     }
     const result = await cloudsearch.runSearch(cloudParams, endpoint)
     return Object.assign({}, {
-      items: result.hits.hit,
+      items: this.transformToDaishoArticleObjectFormat(result.hits.hit),
       count: result.hits.found
     })
   }
@@ -113,7 +137,8 @@ function ArticleSearch () {
     buildQuery: this.buildQuery,
     buildFilters: this.buildFilters,
     setArticleSearchSort: this.setArticleSearchSort,
-    fetchArticles: this.fetchArticles
+    fetchArticles: this.fetchArticles,
+    transformToDaishoArticleObjectFormat: this.transformToDaishoArticleObjectFormat
   }
 }
 

--- a/src/service/article-search.test.js
+++ b/src/service/article-search.test.js
@@ -130,4 +130,141 @@ describe('articleSearch', () => {
       result.should.eql(expected)
     })
   })
+  describe('transformToDaishoArticleObjectFormat', () => {
+    it('should remap an object when all fields are present', () => {
+      const items = [
+        {
+          id: '20351',
+          fields: {
+            article_category: ['Press release'],
+            office: ['6422'],
+            article_programs: ['7(a)'],
+            region: ['National (all regions)'],
+            related_offices: ['17054'],
+            summary: ['summary text'],
+            title: ['CST Article 2 (single input fields)'],
+            created: ['1574192414'],
+            updated: ['1574192835'],
+            url: ['/article/2019/nov/19/cst-article-2-single-input-fields']
+          }
+        }
+      ]
+
+      const expected = [
+        {
+          id: 20351,
+          category: ['Press release'],
+          office: 6422,
+          programs: ['7(a)'],
+          region: ['National (all regions)'],
+          relatedOffices: [17054],
+          summary: 'summary text',
+          type: 'article',
+          title: 'CST Article 2 (single input fields)',
+          created: 1574192414,
+          updated: 1574192835,
+          url: '/article/2019/nov/19/cst-article-2-single-input-fields'
+        }
+      ]
+      const result = articleSearch.transformToDaishoArticleObjectFormat(items)
+      result.should.eql(expected)
+    })
+
+    it('should remap an object with default values when any field is NOT present', () => {
+      const items = [
+        {
+          id: '20351',
+          fields: {}
+        }
+      ]
+
+      const expected = [
+        {
+          id: 20351,
+          category: [],
+          office: {},
+          programs: [],
+          region: [],
+          relatedOffices: [],
+          summary: '',
+          type: 'article',
+          title: '',
+          created: {},
+          updated: {},
+          url: ''
+        }
+      ]
+
+      const result = articleSearch.transformToDaishoArticleObjectFormat(items)
+      result.should.eql(expected)
+    })
+
+    it('should remap an object with stringified numbers converted to numbers for certain fields', () => {
+      const items = [
+        {
+          id: '20351',
+          fields: {
+            office: ['6422'],
+            related_offices: ['17054', '23566'],
+            created: ['1574192414'],
+            updated: ['1574192835']
+          }
+        }
+      ]
+
+      const expected = [
+        {
+          id: 20351,
+          category: [],
+          office: 6422,
+          programs: [],
+          region: [],
+          relatedOffices: [17054, 23566],
+          summary: '',
+          type: 'article',
+          title: '',
+          created: 1574192414,
+          updated: 1574192835,
+          url: ''
+        }
+      ]
+
+      const result = articleSearch.transformToDaishoArticleObjectFormat(items)
+      result.should.eql(expected)
+    })
+
+    it('should remap an object while preserving arrays for certain fields', () => {
+      const items = [
+        {
+          id: '20351',
+          fields: {
+            article_category: ['Notice', 'Press release'],
+            article_programs: ['7(a)', '8(a)'],
+            region: ['Region I', 'Region V'],
+            related_offices: ['17054', '23566']
+          }
+        }
+      ]
+
+      const expected = [
+        {
+          id: 20351,
+          category: ['Notice', 'Press release'],
+          office: {},
+          programs: ['7(a)', '8(a)'],
+          region: ['Region I', 'Region V'],
+          relatedOffices: [17054, 23566],
+          summary: '',
+          type: 'article',
+          title: '',
+          created: {},
+          updated: {},
+          url: ''
+        }
+      ]
+
+      const result = articleSearch.transformToDaishoArticleObjectFormat(items)
+      result.should.eql(expected)
+    })
+  })
 })

--- a/src/service/article-search.test.js
+++ b/src/service/article-search.test.js
@@ -100,7 +100,7 @@ describe('articleSearch', () => {
   describe('buildFilters', () => {
     it('should format filter string for cloudsearch()', () => {
       const params = Object.assign({}, defaultQueryParams)
-      const expected = "(and (or related_offices: '6386') (or office: '3948') (or region: 'Region IV') (or region: 'National') article_programs: 'SBIC' article_category: 'Press release')"
+      const expected = "(and (or related_offices: '6386' office: '3948' region: 'Region IV' region: 'National') article_programs: 'SBIC' article_category: 'Press release')"
       const result = articleSearch.buildFilters(params)
       result.should.eql(expected)
     })

--- a/usage.md
+++ b/usage.md
@@ -15,7 +15,8 @@ Hit the articles endpoint at `*/articles.json`
 |  articleCategory | The category of the article. Articles can be associated with multiple categories
 |  program         | The program that artcle is associated with. Articles can be assoicated with multiple programs
 |  type            | The type of resource being accessed.
-|  relatedOffice   | The ID of an office. This will search Cloudsearch on the `related_offices` field (artices tagged to a certain office) AND the `office` field (articles authored by a certain office).
+|  relatedOffice   | The ID of an office. This will search Cloudsearch on the `related_offices` field (articles tagged to a certain office).
+|  office   | The ID of an office. This will search Cloudsearch on the `office` field (articles authored by a certain office).
 |  region          | The region of an office.
 |  national        | Boolean field that, when `true`, will search Cloudsearch on the `region` field for articles containing a `National` region. This will search Cloudsearch on the related_offices field (artices tagged to a certain office) AND the office field (articles authored by a certain office).
 |  sortBy          | The field that will be sorted determined by the `order` param. Valid inputs are `Title` and `Authored on Date`. Will default to sort on the `updated` field.


### PR DESCRIPTION
for jira ticket https://us-sba.atlassian.net/browse/TA-3441

- [x] The /article page hits the content api with query parameters to get response of corresponding article data

- [x] Since cloudsearch returns articles with a different format, make modifications to use the new format - - a mapping of cloudsearch variables to the variables we already use
- - we moved this functionality to the content api 
- [x] Remove districtOffice query param (from fetch call on district office page) since that is part of the content api’s feature flag
-- this functionality is implemented to katana https://github.com/USSBA/sba-gov-katana/pull/997