### PR TITLE
TA-3540 added cloudsearch single event query by id functionality

### DIFF
--- a/src/service/event-search.js
+++ b/src/service/event-search.js
@@ -134,7 +134,6 @@ EventSearch.prototype.fetchEvents = async function (query) {
     params = {
       query: `event_id: '${queryObj.id}'`,
       return: '_all_fields',
-      sort: 'start_datetime asc',
       queryParser: 'structured',
       size: 1,
       start: 0

--- a/src/service/event-search.js
+++ b/src/service/event-search.js
@@ -128,7 +128,6 @@ EventSearch.prototype.transformToDaishoEventObjectFormat = function (events) {
 
 EventSearch.prototype.fetchEvents = async function (query) {
   const queryObj = query || {}
-  const { address, mapCenter } = queryObj
   let params
   if (queryObj.id) {
     params = {


### PR DESCRIPTION
for jira ticket https://us-sba.atlassian.net/browse/TA-3540

AC:
- [x] the content api endpoint event details uses provides data from events cloudsearch 
can be tested here:
https://avery.ussba.io/api/content/search/events.json?id=304
https://avery.ussba.io/api/content/search/events.json?id=305