### PR TITLE
Feature ta 3576 -  use 'registration_link' key from cloudsearch events domain

### DIFF
--- a/src/service/event-search.js
+++ b/src/service/event-search.js
@@ -92,7 +92,7 @@ EventSearch.prototype.transformToDaishoEventObjectFormat = function (events) {
       title: getValue(fields.name),
       type: 'event',
       description: getValue(fields.description),
-      registrationUrl: getValue(fields.registration_website),
+      registrationUrl: getValue(fields.registration_link),
       startDate: getValue(fields.start_datetime),
       endDate: getValue(fields.end_datetime),
       timezone: getValue(fields.timezone),

--- a/src/service/event-search.test.js
+++ b/src/service/event-search.test.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
 let sinon = require('sinon')
 let chai = require('chai')

--- a/src/service/event-search.test.js
+++ b/src/service/event-search.test.js
@@ -1,4 +1,3 @@
-/* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
 let sinon = require('sinon')
 let chai = require('chai')
@@ -273,7 +272,7 @@ describe('eventSearch', () => {
           id: '20351',
           fields: {
             name: ['My Test Event'],
-            registration_website: ['https://myevent.com/register-here'],
+            registration_link: ['https://myevent.com/register-here'],
             description: ['description text'],
             start_datetime: ['12345678'],
             end_datetime: ['987654321'],

--- a/usage.md
+++ b/usage.md
@@ -380,7 +380,7 @@ Example Response
         "summary": [
           "This is the event summary section."
         ],
-        "registration_website": [
+        "registration_link": [
           "http://registerhere.com"
         ],
         "organizer_name": [


### PR DESCRIPTION
for jira ticket https://us-sba.atlassian.net/browse/TA-3576

AC:
- [x] Content Api is updated to access registration_link from the cloudsearch events domain