### PR TITLE
Feature ta 3614

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -31,9 +31,7 @@ async function fetchContentById (params, headers) {
     node: fetchFormattedNode
   }
 
-  if (config.eventsApi.getBackendSourceToggle() !== 'true') {
-    fetchFunctionsMap.events = events.fetchEventById
-  }
+  fetchFunctionsMap.events = config.eventsApi.getBackendSourceToggle() !== 'true' ? events.fetchEventById : events.fetchEvents
 
   if (params && params.type && params.id) {
     const type = params.type
@@ -42,7 +40,8 @@ async function fetchContentById (params, headers) {
 
     if (fetchFunction) {
       try {
-        let result = await fetchFunction(id, {
+        const args = config.eventsApi.getBackendSourceToggle() === 'true' && type === 'events' ? { id } : id
+        let result = await fetchFunction(args, {
           headers
         })
         if (result) {

--- a/src/content.js
+++ b/src/content.js
@@ -32,7 +32,7 @@ async function fetchContentById (params, headers) {
   }
 
   if (config.eventsApi.getBackendSourceToggle() !== 'true') {
-    fetchFunctionsMap.event = events.fetchEventById
+    fetchFunctionsMap.events = events.fetchEventById
   }
 
   if (params && params.type && params.id) {

--- a/src/content.test.js
+++ b/src/content.test.js
@@ -39,8 +39,8 @@ describe('# Content Handler', () => {
       eventStub.withArgs(1).returns(data)
 
       let expected = { statusCode: HttpStatus.OK, body: data }
-      let result = await contentHandler.fetchContentById({ type: 'event', id: 1 })
-
+      let result = await contentHandler.fetchContentById({ type: 'events', id: 1 })
+      
       expect(result).to.deep.equal(expected)
     })
 
@@ -48,8 +48,8 @@ describe('# Content Handler', () => {
       getBackendSourceToggleStub.returns('false')
       eventStub.returns(null)
 
-      let expected = { statusCode: HttpStatus.NOT_FOUND, body: 'Unable to find event with id 1' }
-      let result = await contentHandler.fetchContentById({ type: 'event', id: 1 })
+      let expected = { statusCode: HttpStatus.NOT_FOUND, body: 'Unable to find events with id 1' }
+      let result = await contentHandler.fetchContentById({ type: 'events', id: 1 })
 
       expect(result).to.deep.equal(expected)
     })
@@ -58,8 +58,8 @@ describe('# Content Handler', () => {
       const id = 1
       getBackendSourceToggleStub.returns('true')
 
-      let expected = { statusCode: HttpStatus.NOT_FOUND, body: 'Unknown type event' }
-      let result = await contentHandler.fetchContentById({ type: 'event', id })
+      let expected = { statusCode: HttpStatus.NOT_FOUND, body: 'Unknown type events' }
+      let result = await contentHandler.fetchContentById({ type: 'events', id })
 
       expect(result).to.deep.equal(expected)
     })

--- a/src/content.test.js
+++ b/src/content.test.js
@@ -58,9 +58,8 @@ describe('# Content Handler', () => {
       const id = 1
       getBackendSourceToggleStub.returns('true')
 
-      let expected = { statusCode: HttpStatus.NOT_FOUND, body: 'Unknown type events' }
-      let result = await contentHandler.fetchContentById({ type: 'events', id })
-
+      let expected = { statusCode: HttpStatus.NOT_FOUND, body: 'Unknown type event' }
+      let result = await contentHandler.fetchContentById({ type: 'event', id })
       expect(result).to.deep.equal(expected)
     })
   })

--- a/src/content.test.js
+++ b/src/content.test.js
@@ -40,7 +40,7 @@ describe('# Content Handler', () => {
 
       let expected = { statusCode: HttpStatus.OK, body: data }
       let result = await contentHandler.fetchContentById({ type: 'events', id: 1 })
-      
+
       expect(result).to.deep.equal(expected)
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,16 +18,15 @@ async function run (event) {
   let result = null
   console.log(JSON.stringify(event))
   if (event && event.pathParameters) {
-    let pathParams = event.pathParameters
+    const { queryStringParameters, pathParameters } = event
     let fetchResult = ''
     let foundExtension
-    if (pathParams.id) {
-      let type = pathParams.type
-      let { first: id, second: extension } = splitAsObject(pathParams.id)
-      fetchResult = await content.fetchContentById({ id, type, extension }, event.headers || {})
+    if (queryStringParameters && queryStringParameters.id) {
+      let { first: type, second: extension } = splitAsObject(pathParameters.type)
+      fetchResult = await content.fetchContentById({ id: queryStringParameters.id, type, extension }, event.headers || {})
       foundExtension = extension
     } else {
-      let { first: type, second: extension } = splitAsObject(pathParams.type)
+      let { first: type, second: extension } = splitAsObject(pathParameters.type)
       fetchResult = await content.fetchContentByType({ type, extension }, event.queryStringParameters || {})
       foundExtension = extension
     }

--- a/src/service/events.js
+++ b/src/service/events.js
@@ -127,14 +127,14 @@ function mapD7EventDataToBetterSchema (item) {
 }
 
 async function fetchEventById (id) {
-  let result = await eventClient.getEvents({ nid: id })
-  if (Array.isArray(result) && result.length !== 0) {
-    return {
-      items: [mapD7EventDataToBetterSchema(result[0])]
-    }
-  } else {
-    return {}
+  let event = await eventClient.getEvents({ nid: id })
+  const result = {
+    items: []
   }
+  if (Array.isArray(event) && event.length !== 0) {
+    result.items = [mapD7EventDataToBetterSchema(event[0])]
+  }
+  return result
 }
 
 async function fetchTotalLength (params) {

--- a/src/service/events.js
+++ b/src/service/events.js
@@ -129,7 +129,9 @@ function mapD7EventDataToBetterSchema (item) {
 async function fetchEventById (id) {
   let result = await eventClient.getEvents({ nid: id })
   if (Array.isArray(result) && result.length !== 0) {
-    return mapD7EventDataToBetterSchema(result[0])
+    return {
+      items: [mapD7EventDataToBetterSchema(result[0])]
+    }
   } else {
     return {}
   }

--- a/src/service/events.test.js
+++ b/src/service/events.test.js
@@ -52,7 +52,7 @@ describe('Event Service for D7', () => {
     it('should fetch and map data for a single event', async () => {
       eventClientStub.returns(mockD7Response1)
       const result = await events.fetchEventById(mockD7Response1[0].nid)
-      result.should.eql(expectedEventsData1.items[0])
+      result.items[0].should.eql(expectedEventsData1.items[0])
     })
   })
 


### PR DESCRIPTION
for jira ticket https://us-sba.atlassian.net/browse/TA-3614

AC:
- [x] The D7 Event detail page is fixed

Before, now matter what event was clicked on, only the most recent event detail information displayed.

Now, any event that is clicked on from https://avery.ussba.io/events/ will open to its correct event detail information.