### PR TITLE
Search by lender

### DIFF
--- a/src/service/lender-search.js
+++ b/src/service/lender-search.js
@@ -9,14 +9,6 @@ const defaultGeocode = {
   longitude: -77.014647
 }
 
-function buildFilters (hasFiled2019Taxes) {
-  let filterString = null
-  if (hasFiled2019Taxes === 'true') {
-    filterString = 'is_fast_track: 1'
-  }
-  return filterString
-}
-
 function buildDefaultQueryParams (geo) {
   let { latitude, longitude } = geo
   const numberOfResults = 1
@@ -38,19 +30,21 @@ function buildDefaultQueryParams (geo) {
 }
 
 function buildParams (query, geo) {
-  const { pageSize, start, hasFiled2019Taxes } = query
+  const { pageSize, start, lenderName } = query
   const { latitude, longitude } = geo
   const defaultPageSize = 5
   const defaultStart = 0
+  const queryString = lenderName ? `lender_name: '${cloudsearch.formatString(lenderName)}'` : 'matchall'
+
   let params = {
-    query: 'matchall',
-    filterQuery: buildFilters(hasFiled2019Taxes),
+    query: queryString,
     return: '_all_fields',
     sort: 'lender_name asc',
     queryParser: 'structured',
     size: pageSize || defaultPageSize,
     start: start || defaultStart
   }
+
   if (latitude && longitude) {
     params = Object.assign({}, params, {
       sort: 'distance asc',

--- a/src/service/lender-search.test.js
+++ b/src/service/lender-search.test.js
@@ -164,10 +164,10 @@ describe('# Lender Search', () => {
         result.start.should.eql(exampleCloudSearchEmptyResponse.hits.start)
       })
 
-      it('should it should search by lenders nearest to the geographic location when lender name is passed in', async () => {
+      it('should search by lenders nearest to the geographic location when lender name is passed in', async () => {
         dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
         lenderSearchRunSearchStub.returns(exampleCloudSearchEmptyResponse)
-        let result = await lenderSearch.fetchLenders({ address: '06870', lenderName: 'Chase Bank' })
+        const result = await lenderSearch.fetchLenders({ address: '06870', lenderName: 'Chase Bank' })
 
         lenderSearchRunSearchStub.calledWith({
           query: "lender_name: 'Chase Bank'",

--- a/src/service/lender-search.test.js
+++ b/src/service/lender-search.test.js
@@ -147,7 +147,6 @@ describe('# Lender Search', () => {
         result.start.should.eql(exampleCloudSearchEmptyResponse.hits.start)
       })
 
-
       it('should properly handle an empty address', async () => {
         dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
         lenderSearchRunSearchStub.returns(exampleCloudSearchEmptyResponse)

--- a/src/service/lender-search.test.js
+++ b/src/service/lender-search.test.js
@@ -178,7 +178,6 @@ describe('# Lender Search', () => {
           start: 0,
           expr: '{"distance":"haversin(41.033347,-73.568040,geolocation.latitude,geolocation.longitude)"}'
         }).should.be.true
-        console.log('lenderSearch stub', lenderSearchRunSearchStub)
         result.hit.should.eql(exampleCloudSearchEmptyResponse.hits.hit)
         result.found.should.eql(exampleCloudSearchEmptyResponse.hits.found)
         result.start.should.eql(exampleCloudSearchEmptyResponse.hits.start)

--- a/src/service/lender-search.test.js
+++ b/src/service/lender-search.test.js
@@ -135,7 +135,6 @@ describe('# Lender Search', () => {
         let result = await lenderSearch.fetchLenders({ address: '06870' })
         lenderSearchRunSearchStub.calledWith({
           query: 'matchall',
-          filterQuery: null,
           queryParser: 'structured',
           return: '_all_fields,distance',
           sort: 'distance asc',
@@ -148,13 +147,13 @@ describe('# Lender Search', () => {
         result.start.should.eql(exampleCloudSearchEmptyResponse.hits.start)
       })
 
+
       it('should properly handle an empty address', async () => {
         dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
         lenderSearchRunSearchStub.returns(exampleCloudSearchEmptyResponse)
         let result = await lenderSearch.fetchLenders({ address: null })
         lenderSearchRunSearchStub.calledWith({
           query: 'matchall',
-          filterQuery: null,
           queryParser: 'structured',
           return: '_all_fields',
           sort: 'lender_name asc',
@@ -166,37 +165,21 @@ describe('# Lender Search', () => {
         result.start.should.eql(exampleCloudSearchEmptyResponse.hits.start)
       })
 
-      it('should set the filterQuery param for cloudsearch query when hasFiled2019Taxes query parameter is passed in', async () => {
+      it('should it should search by lenders nearest to the geographic location when lender name is passed in', async () => {
         dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
         lenderSearchRunSearchStub.returns(exampleCloudSearchEmptyResponse)
-        let result = await lenderSearch.fetchLenders({ hasFiled2019Taxes: 'true' })
-        lenderSearchRunSearchStub.calledWith({
-          query: 'matchall',
-          filterQuery: 'is_fast_track: 1',
-          queryParser: 'structured',
-          return: '_all_fields',
-          sort: 'lender_name asc',
-          size: 5,
-          start: 0
-        }).should.be.true
-        result.hit.should.eql(exampleCloudSearchEmptyResponse.hits.hit)
-        result.found.should.eql(exampleCloudSearchEmptyResponse.hits.found)
-        result.start.should.eql(exampleCloudSearchEmptyResponse.hits.start)
-      })
+        let result = await lenderSearch.fetchLenders({ address: '06870', lenderName: 'Chase Bank' })
 
-      it('should NOT set the filterQuery param for cloudsearch query when hasFiled2019Taxes query parameter is empty', async () => {
-        dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
-        lenderSearchRunSearchStub.returns(exampleCloudSearchEmptyResponse)
-        let result = await lenderSearch.fetchLenders({ hasFiled2019Taxes: '' })
         lenderSearchRunSearchStub.calledWith({
-          query: 'matchall',
-          filterQuery: null,
+          query: "lender_name: 'Chase Bank'",
           queryParser: 'structured',
-          return: '_all_fields',
-          sort: 'lender_name asc',
+          return: '_all_fields,distance',
+          sort: 'distance asc',
           size: 5,
-          start: 0
+          start: 0,
+          expr: '{"distance":"haversin(41.033347,-73.568040,geolocation.latitude,geolocation.longitude)"}'
         }).should.be.true
+        console.log('lenderSearch stub', lenderSearchRunSearchStub)
         result.hit.should.eql(exampleCloudSearchEmptyResponse.hits.hit)
         result.found.should.eql(exampleCloudSearchEmptyResponse.hits.found)
         result.start.should.eql(exampleCloudSearchEmptyResponse.hits.start)


### PR DESCRIPTION
This pull request updates the API to search by lender_name if the user submits the form with one along with zip code. It will still search by zip code which calculates the geolocation then sort the lenders from nearest to farthest. 