### PR TITLE
Bug/no distance when no geo

### DIFF
--- a/src/service/office-search.js
+++ b/src/service/office-search.js
@@ -106,7 +106,7 @@ async function fetchOffices (query) {
       const newHitList = hits.hit.map(item => {
         let _item = item
         if (item && item.exprs && item.exprs.distance >= 0) {
-          if (!address) {
+          if (!address || !item.fields.geolocation) {
             _item = Object.assign({}, item)
             delete _item.exprs
           } else {

--- a/src/service/office-search.test.js
+++ b/src/service/office-search.test.js
@@ -35,6 +35,34 @@ let exampleDynamoDBResponse = {
   ScannedCount: 1
 }
 
+let exampleCloudSearchNoGeoResponse = {
+  status: { timems: 3, rid: '3sCN9b4slBwKlnJa' },
+  hits: {
+    found: 526,
+    start: 0,
+    hit: [
+      {
+        id: '5663',
+        fields: {
+          location_city: ['Bozeman'],
+          location_state: ['MT'],
+          location_zipcode: ['59717'],
+          location_name: ['Bozeman'],
+          location_hours_of_operation: ['Monday through Friday from 9 a.m. to 5 p.m.'],
+          title: ['406 Labs'],
+          office_type: ['Startup accelerator'],
+          office_website: ['http://www.montana.edu/launchpad/accelerator.html'],
+          type: ['office'],
+          location_street_address: ['251 A&B Strand Union Building']
+        },
+        exprs: {
+          distance: 100
+        }
+      }
+    ]
+  }
+}
+
 let exampleCloudSearchResponse = {
   status: { timems: 3, rid: '3sCN9b4slBwKlnJa' },
   hits: {
@@ -157,6 +185,21 @@ describe('# Office Search', () => {
       let result = await officeSearch.fetchOffices({ mapCenter: '1,1' })
       result.hit[0].hasOwnProperty('exprs').should.be.false
       result.hit[1].hasOwnProperty('exprs').should.be.false
+    })
+
+    it('should not return distance when no geolocation is present in the data for district office', async () => {
+      dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
+      officeSearchRunSearchStub.returns(exampleCloudSearchNoGeoResponse)
+    })
+
+    it('should not return city when no geolocation is present in the data for district office', async () => {
+      dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
+      officeSearchRunSearchStub.returns(exampleCloudSearchNoGeoResponse)
+    })
+
+    it('should return distance when no geolocation is present in the data non district offices', async () => {
+      dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
+      officeSearchRunSearchStub.returns(exampleCloudSearchNoGeoResponse)
     })
 
     it('should return distance when there is an address parameter present', async () => {

--- a/src/service/office-search.test.js
+++ b/src/service/office-search.test.js
@@ -190,16 +190,8 @@ describe('# Office Search', () => {
     it('should not return distance when no geolocation is present in the data for district office', async () => {
       dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
       officeSearchRunSearchStub.returns(exampleCloudSearchNoGeoResponse)
-    })
-
-    it('should not return city when no geolocation is present in the data for district office', async () => {
-      dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
-      officeSearchRunSearchStub.returns(exampleCloudSearchNoGeoResponse)
-    })
-
-    it('should return distance when no geolocation is present in the data non district offices', async () => {
-      dynamoDbClientQueryStub.returns(exampleDynamoDBResponse)
-      officeSearchRunSearchStub.returns(exampleCloudSearchNoGeoResponse)
+      let result = await officeSearch.fetchOffices({ address: '21202' })
+      result.hit[0].hasOwnProperty('exprs').should.be.false
     })
 
     it('should return distance when there is an address parameter present', async () => {


### PR DESCRIPTION
The following pull request will remove the distance calculations if the district office does not have the geocode data. The geocode data should be present for each office but should it not be, the distance is miss calculated. Therefore better to place this code as a safety measure should the data not return the geocode. 